### PR TITLE
Handle the case when matrix is nil

### DIFF
--- a/lib/deprecations_collector/main.rb
+++ b/lib/deprecations_collector/main.rb
@@ -59,6 +59,8 @@ module DeprecationsCollector
     end
 
     def save_results(matrix = @coverage_matrix, file_name: ENV['MATRIX_FILENAME'] || 'deprecations_collector.yml')
+      matrix = {} if matrix.nil?
+
       path = File.join(output_path, file_name)
       FileUtils.mkdir_p(output_path)
 


### PR DESCRIPTION
If matrix has `nil` value then the code
fails at matrix.sort
Hence handled this case to avoid this error