### PR TITLE
Handle the case when matrix is nil

### DIFF
--- a/lib/deprecations_detector/main.rb
+++ b/lib/deprecations_detector/main.rb
@@ -57,6 +57,8 @@ module DeprecationsDetector
     end
 
     def save_results(matrix = @coverage_matrix, file_name: ENV['MATRIX_FILENAME'] || 'deprecations_detector.yml')
+      matrix = {} if matrix.nil?
+
       path = File.join(output_path, file_name)
       FileUtils.mkdir_p(output_path)
 

--- a/lib/deprecations_detector/version.rb
+++ b/lib/deprecations_detector/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeprecationsDetector
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
If matrix has `nil` value then the code
fails at matrix.sort
Hence handled this case to avoid this error