### PR TITLE
Group message without file path and line

### DIFF
--- a/lib/deprecations_detector/formatters/html/formatter.rb
+++ b/lib/deprecations_detector/formatters/html/formatter.rb
@@ -96,7 +96,13 @@ module DeprecationsDetector
           grouped_files = []
 
           groups.each do |deprecation_message|
-            grouped[deprecation_message] = files.select { |source_file, lines| lines.detect { |line, examples| examples.detect { |example| example[:deprecation_message] == deprecation_message } } }
+            grouped[deprecation_message] = files.select do |source_file, lines|
+              lines.detect do |line, examples|
+                examples.detect do |example|
+                  example[:deprecation_message] == deprecation_message
+                end
+              end
+            end
             grouped_files += grouped[deprecation_message].keys
           end
           if !groups.empty? && !(other_files = files.reject { |source_file| grouped_files.include?(source_file) }).empty?

--- a/lib/deprecations_detector/main.rb
+++ b/lib/deprecations_detector/main.rb
@@ -48,7 +48,7 @@ module DeprecationsDetector
       file_path = result[1] # "#{Dir.pwd}#{result[1]}"
 
       @deprecation_matrix[file_path] ||= {}
-      @deprecation_matrix[file_path][result[2].to_i - 1] = message
+      @deprecation_matrix[file_path][result[2].to_i - 1] = /(.*)\(called.*\)/m.match(message)[1]
     end
 
     def start

--- a/lib/deprecations_detector/version.rb
+++ b/lib/deprecations_detector/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeprecationsDetector
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end


### PR DESCRIPTION
The deprecation message from ActiveSupport now contains the path and line information. This commit crops it in order to allow to group the deprecations by deprecation message.